### PR TITLE
Add note about Webpack bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In your Babel configuration:
 }
 ```
 
-<sub>Note that Webpack outputs a bundle wrapped with iife by default.</sub>
+_Note that Webpack outputs a bundle wrapped with iife by default._
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ In your Babel configuration:
 }
 ```
 
+<sub>Note that Webpack outputs a bundle wrapped with iife by default.</sub>
+
 
 ## Contributing
 


### PR DESCRIPTION
I spent some time spinning my wheels over trying to get imports working with babel-plugin-iife-wrap and Webpack. It turns out I didn't need this plugin since Webpack already bundles my code inside an iife.

Since this is a note about something outside of Babel I put it in small text. Please let me know if anything could be changed in any way to make it more readable. 